### PR TITLE
Trim entity names before finding a matching token

### DIFF
--- a/scripts/token-replacer.js
+++ b/scripts/token-replacer.js
@@ -368,8 +368,8 @@ function preCreateTokenHook(data, options, userId) {
 
 // replace the artwork for a NPC actor with the version from this module
 function replaceArtWork(data) {
-    const formattedName = escape(data.name.replace(/ /g, "_"));
-	const diffDir = (difficultyName) ? `${String(getProperty(data, difficultyVariable)).replace(".", "_")}/` : "";
+    const formattedName = escape(data.name.trim().replace(/ /g, "_"));
+    const diffDir = (difficultyName) ? `${String(getProperty(data, difficultyVariable)).replace(".", "_")}/` : "";
     const tokenCheck = `${tokenDirectory.current}/${difficultyName}${diffDir}${formattedName}`;
     
     const filteredCachedTokens = cachedTokens.filter(t => t.toLowerCase().indexOf(tokenCheck.toLowerCase()) >= 0);


### PR DESCRIPTION
Some compendiums, often those auto-converted from external resources or
PDF files, may have trailing spaces.
Trimming the names ensures that these cases are still matched correctly.

I have [an open PR](https://gitlab.com/hooking/foundry-vtt---pathfinder-2e/-/merge_requests/1891#1a83599359e6983365072e2bba3d4b38f634156f) in the pf2e module where this initially occured for me,
but I figured rather than fixing individual sources that have untrimmed names,
the token-replacer should just handle them all properly by also trimming the names.