### PR TITLE
Release/0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.4
+
+* Fixed an issue with saving settings when 'Use NPC Difficulty Folder Structure' is unchecked
+* Removed the mystery man check for portrait on token creation, since we have a portrait prefix to force portraits to one specific image
+
 # 0.4.3
 
 * Rename debug variable to more unique name as it causes issue with other modules

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "name": "token-replacer",
     "title": "Token Replacer",
     "description": "Automatically replace NPC actor tokens and/or portraits dependant on token assests saved in a defined folder structure.",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "authors": [
       {
         "name": "VTT Lair",
@@ -25,7 +25,7 @@
     ],
     "url": "https://github.com/vtt-lair/token-replacer",
     "manifest": "https://github.com/vtt-lair/token-replacer/releases/latest/download/module.json",
-    "download": "https://github.com/vtt-lair/token-replacer/releases/download/v0.4.3/token-replacer-v0.4.3.zip",
+    "download": "https://github.com/vtt-lair/token-replacer/releases/download/v0.4.3/token-replacer-v0.4.4.zip",
     "minimumCoreVersion": "0.7.7",
     "compatibleCoreVersion": "0.7.9"
 }

--- a/module.json
+++ b/module.json
@@ -25,7 +25,7 @@
     ],
     "url": "https://github.com/vtt-lair/token-replacer",
     "manifest": "https://github.com/vtt-lair/token-replacer/releases/latest/download/module.json",
-    "download": "https://github.com/vtt-lair/token-replacer/releases/download/v0.4.3/token-replacer-v0.4.4.zip",
+    "download": "https://github.com/vtt-lair/token-replacer/releases/download/v0.4.4/token-replacer-v0.4.4.zip",
     "minimumCoreVersion": "0.7.7",
     "compatibleCoreVersion": "0.7.9"
 }

--- a/scripts/token-replacer.js
+++ b/scripts/token-replacer.js
@@ -116,7 +116,7 @@ class TokenReplacerSetup extends FormApplication {
         nameFormats.forEach((x) => {
             x.selected = false;
         });
-        if (imageNameIdx !== null && imageNameIdx > -1) {
+        if (imageNameIdx !== null && imageNameIdx > -1 && nameFormats[imageNameIdx]) {
             nameFormats[imageNameIdx].selected = true;
         }
 
@@ -125,7 +125,7 @@ class TokenReplacerSetup extends FormApplication {
         folderFormats.forEach((x) => {
             x.selected = false;
         });
-        if (imageNameIdx !== null && imageNameIdx > -1) {
+        if (folderNameIdx !== null && folderNameIdx > -1) {
             folderFormats[folderNameIdx].selected = true;
         }
 
@@ -705,8 +705,7 @@ function replaceArtWork(data) {
     // otherwise the portrait art will change every time we put a token on the scene
     if (
         (replaceToken === 2 || replaceToken === 3) &&
-        (filteredCachedPortraits && filteredCachedPortraits.length > 0) &&
-        (!hookedFromTokenCreation || data.img === 'icons/svg/mystery-man.svg')
+        (filteredCachedPortraits && filteredCachedPortraits.length > 0)
     ) {
         let randomIdx = Math.floor(Math.random() * (filteredCachedPortraits.length * filteredCachedPortraits.length));
         randomIdx = Math.floor(randomIdx / filteredCachedPortraits.length);


### PR DESCRIPTION
Fixed an issue with saving settings when 'Use NPC Difficulty Folder Structure' is unchecked
Removed the mystery man check for portrait on token creation, since we have a portrait prefix to force portraits to one specific image