### PR TITLE
Change encoded symbols to escaped for comparison.

### DIFF
--- a/scripts/token-replacer.js
+++ b/scripts/token-replacer.js
@@ -576,9 +576,9 @@ const TokenReplacer = {
                 console.log(`Token Replacer: searching for portrait for ${portraitCheck}`);
             }
     
-            let filteredCachedTokens = tr_cachedTokens.filter(t => t.toLowerCase().indexOf(tokenCheck) >= 0);
-            filteredCachedTokens = filteredCachedTokens.filter(t => t.toLowerCase().indexOf(tr_portraitPrefix) === -1);
-            let filteredCachedPortraits = tr_cachedTokens.filter(t => t.toLowerCase().indexOf(portraitCheck) >= 0);
+            let filteredCachedTokens = tr_cachedTokens.filter(t => escape(decodeURI(t)).toLowerCase().indexOf(tokenCheck) >= 0);
+            filteredCachedTokens = filteredCachedTokens.filter(t => escape(decodeURI(t)).toLowerCase().indexOf(tr_portraitPrefix) === -1);
+            let filteredCachedPortraits = tr_cachedTokens.filter(t => escape(decodeURI(t)).toLowerCase().indexOf(portraitCheck) >= 0);
             filteredCachedPortraits = (filteredCachedPortraits) ?? filteredCachedTokens;
             if (!filteredCachedPortraits.length) {
                 filteredCachedPortraits = filteredCachedTokens;


### PR DESCRIPTION
Non-UTF symbols are treated differently in the code. Symbols are encoded (using encodeURI) when files are read from the file system, and in the tr_cachedTokens files are stored in an encoded way (example: %D0%A8). And when we try to find the file, we read the name of the character, and escape it- so the name is stored as ("%u0440").  These two ways of storing symbols are not equal, so comparison not working if such symbols are in the token name (any non-English characters).  Here is the simplest change to fix that problem.

Feel free to ping me in discord for any questions (ВладимирВ#8162)

P.S. I am not JS developer, I prefer Java/Kotlin/C, so may be there is a better way to do that fix.